### PR TITLE
Distance heuristic instead of exact calculation

### DIFF
--- a/source/v1.1/PlayerControlPatch.cs
+++ b/source/v1.1/PlayerControlPatch.cs
@@ -184,7 +184,7 @@ namespace SheriffMod
                 if (player.PlayerId != refplayer.PlayerId)
                 {
 
-                    double dist = getDistBetweenPlayers(player, refplayer);
+                    double dist = getDistBetweenPlayersHeuristic(player, refplayer);
                     if (dist < mindist)
                     {
                         mindist = dist;
@@ -198,12 +198,12 @@ namespace SheriffMod
 
         }
 
-        public static double getDistBetweenPlayers(FFGALNAPKCD player, FFGALNAPKCD refplayer)
+        public static double getDistBetweenPlayersHeuristic(FFGALNAPKCD player, FFGALNAPKCD refplayer)
         {
             var refpos = refplayer.GetTruePosition();
             var playerpos = player.GetTruePosition();
 
-            return Math.Sqrt((refpos[0] - playerpos[0]) * (refpos[0] - playerpos[0]) + (refpos[1] - playerpos[1]) * (refpos[1] - playerpos[1]));
+            return (refpos[0] - playerpos[0]) * (refpos[0] - playerpos[0]) + (refpos[1] - playerpos[1]) * (refpos[1] - playerpos[1]);
         }
 
         [HarmonyPatch(typeof(FFGALNAPKCD), "RpcSetInfected")]


### PR DESCRIPTION
if x>y then x^2>y^2

There is no need to Math.sqrt to find the closest player if you used the distance squared heuristic. This will still find the closest player and will be faster by eliminating the need to call the expensive Math.sqrt lib function.